### PR TITLE
refactor: argument parser 분리하기

### DIFF
--- a/src/etc/cmdFlags.ts
+++ b/src/etc/cmdFlags.ts
@@ -1,0 +1,17 @@
+interface StringListMap {
+    [key: string]: string[];
+}
+
+const FlagMap : StringListMap = {
+    due: ['--due', '-d', '--time', '-t'],
+    content: ['--content', '-c'],
+    progress: ['--progress', '--prog', '-p'],
+    goal: ['--goal', '-g'],
+    help: ['--help', '-h']
+}
+
+const getFlags = (name : string) => {
+    return FlagMap[name];
+}
+
+export default getFlags;

--- a/src/module/bar/onBarAdd.ts
+++ b/src/module/bar/onBarAdd.ts
@@ -5,6 +5,7 @@ import { isInteger } from '../../etc/isInteger';
 import preprocessContent from '../../etc/preprocessContent';
 import { addBar, getBars } from '../../database/bar';
 import { validateBar } from '../../etc/validateBar';
+import getFlags from '../../etc/cmdFlags';
 
 let isSlackDecoration = (text: string) => {
   let match = text.match(/[~_]+/);
@@ -31,8 +32,8 @@ function makeUnique<T>(arr: T[]) {
 const onBarAdd = async ({ command, args }: QueryType, event: any, user: UserType) => {
   let bars = await getBars(user.id);
 
-  const progArg = getArg(['--progress', '--prog', '-p'], args);
-  const goalArg = getArg(['--goal', '-g'], args);
+  const progArg = getArg(getFlags('progress'), args);
+  const goalArg = getArg(getFlags('goal'), args);
 
   let _prog = 0;
   if(progArg) {

--- a/src/module/bar/onBarEdit.ts
+++ b/src/module/bar/onBarEdit.ts
@@ -5,13 +5,14 @@ import { isInteger } from '../../etc/isInteger';
 import preprocessContent from '../../etc/preprocessContent';
 import { BarType, editBar, getBars } from '../../database/bar';
 import { validateBar } from '../../etc/validateBar';
+import getFlags from '../../etc/cmdFlags';
 
 
 const onBarEdit = async ({ command, args }: QueryType, event: any, user: UserType) => {
     let bars = await getBars(user.id);
 
-    const progArg = getArg(['--progress', '--prog', '-p'], args);
-    const goalArg = getArg(['--goal', '-g'], args);
+    const progArg = getArg(getFlags('progress'), args);
+    const goalArg = getArg(getFlags('goal'), args);
 
     let newProg: number | undefined;
     if(progArg) {
@@ -45,7 +46,7 @@ const onBarEdit = async ({ command, args }: QueryType, event: any, user: UserTyp
         newGoal = undefined;
     }
 
-  const contentArg = getArg(['--content', '-c'], args);
+  const contentArg = getArg(getFlags('content'), args);
 
   let newContent : string | undefined;
 

--- a/src/module/todo/onTodoAdd.ts
+++ b/src/module/todo/onTodoAdd.ts
@@ -6,6 +6,7 @@ import { getArg, QueryType } from '../../etc/parseQuery';
 import stringToTime from '../../etc/stringToTime';
 import { reduceEachTrailingCommentRange } from 'typescript';
 import preprocessContent from '../../etc/preprocessContent';
+import getFlags from '../../etc/cmdFlags'
 
 let isSlackDecoration = (text: string) => {
   let match = text.match(/[~_]+/);
@@ -33,7 +34,7 @@ function makeUnique<T>(arr: T[]) {
 const onTodoAdd = async ({ command, args }: QueryType, event: any, user: UserType) => {
   let todo = await getCstodos(user.id);
 
-  const dueArg = getArg(['--due', '-d', '--time', '-t'], args);
+  const dueArg = getArg(getFlags('due'), args);
 
   let _due = 0;
   if (!dueArg) {

--- a/src/module/todo/onTodoEdit.ts
+++ b/src/module/todo/onTodoEdit.ts
@@ -6,6 +6,7 @@ import { getArg, QueryType } from '../../etc/parseQuery';
 import stringToTime from '../../etc/stringToTime';
 import timeToString from '../../etc/timeToString';
 import preprocessContent from '../../etc/preprocessContent';
+import getFlags from '../../etc/cmdFlags';
 
 const isInteger = (s: string) => {
   for (let c of s.split('')) {
@@ -17,7 +18,7 @@ const isInteger = (s: string) => {
 const onTodoEdit = async ({ command, args }: QueryType, event: any, user: UserType) => {
   let todo = await getCstodos(user.id);
 
-  const dueArg = getArg(['--due', '-d', '--time', '-t'], args);
+  const dueArg = getArg(getFlags('due'), args);
 
   let newDue: number | undefined;
   if (!dueArg) {
@@ -34,7 +35,7 @@ const onTodoEdit = async ({ command, args }: QueryType, event: any, user: UserTy
     return;
   }
 
-  const contentArg = getArg(['--content', '-c'], args);
+  const contentArg = getArg(getFlags('content'), args);
 
   let newContent : string | undefined;
 


### PR DESCRIPTION
helper 보강, todo-bar 통합의 기초 공사로, cmd line argument들을 task에 사용할 수 있는 형태로 분리합니다.

- [x] `etc/cmdFlags` 에 argument parser 만들기
- [ ] 각 커맨드별 helpText 및 help argument 활성화
- [ ] flag가 가리키는 argument parser 새 모듈로 분리하기