### PR TITLE
SlackMessageEvent 타입 추가

### DIFF
--- a/src/etc/postMessage.ts
+++ b/src/etc/postMessage.ts
@@ -24,7 +24,6 @@ export const addEmoji = async (event: SlackMessageEvent, emojiName: string) => {
 }
 
 export enum ForceMuteType {
-    None,
     Unmute,
     Mute
 }

--- a/src/etc/postMessage.ts
+++ b/src/etc/postMessage.ts
@@ -4,13 +4,14 @@ import { webClient } from '..';
 import { emoji } from './theme';
 import { cstodoChannel, cstodoTestChannel } from '../config';
 import { UserType } from '../database/user';
+import { SlackMessageEvent } from '../slack/event';
 
 
 export const postMessage = async (props: ChatPostMessageArguments) => {    
     await webClient.chat.postMessage(props);
 }
 
-export const addEmoji = async (event: any, emojiName: string) => {
+export const addEmoji = async (event: SlackMessageEvent, emojiName: string) => {
     try {
         await webClient.reactions.add({
             name: emojiName,
@@ -22,12 +23,17 @@ export const addEmoji = async (event: any, emojiName: string) => {
     }
 }
 
+export enum ForceMuteType {
+    None,
+    Unmute,
+    Mute
+}
+
 interface Options {
-    forceUnmute?: boolean;
-    forceMute?: boolean;
+    forceMuteType?: ForceMuteType;
 };
 
-export const replyDdokddul = async (event: any, user: UserType, message: string, options?: Options) => {
+export const replyDdokddul = async (event: SlackMessageEvent, user: UserType, message: string, options?: Options) => {
     await replyMessage(event, user, {
         text: "",
         username: `${user.name}님의 똑떨한 비서`,
@@ -40,7 +46,7 @@ export const replyDdokddul = async (event: any, user: UserType, message: string,
     }, options);
 }
 
-export const replySuccess = async (event: any, user: UserType, message: string, icon_emoji?: string, options?: Options) => {
+export const replySuccess = async (event: SlackMessageEvent, user: UserType, message: string, icon_emoji?: string, options?: Options) => {
     let emoji_kw = 'default';
     if (icon_emoji !== undefined) {
         emoji_kw = icon_emoji;
@@ -57,7 +63,7 @@ export const replySuccess = async (event: any, user: UserType, message: string, 
     }, options);
 }
 
-export const replyFail = async (event: any, user: UserType, message: string, options?: Options) => {
+export const replyFail = async (event: SlackMessageEvent, user: UserType, message: string, options?: Options) => {
     await replyMessage(event, user, {
         text: "",
         username: `${user.name}님의 똑떨한 비서`,
@@ -76,12 +82,12 @@ export const replyFail = async (event: any, user: UserType, message: string, opt
     });
 }
 
-export const replyMessage = async (event: any, user: UserType | undefined, props: ChatPostMessageArguments, options?: Options) => {   
+export const replyMessage = async (event: SlackMessageEvent, user: UserType | undefined, props: ChatPostMessageArguments, options?: Options) => {
 
-    let muted = user && user.muted;
+    let muted = user?.muted;
 
-    if (options && options.forceMute) muted = true;
-    if (options && options.forceUnmute) muted = false;
+    if (options?.forceMuteType === ForceMuteType.Mute) muted = true;
+    else if (options?.forceMuteType === ForceMuteType.Unmute) muted = false;
 
     if (muted) {
         await webClient.chat.postEphemeral({

--- a/src/module/bar/index.ts
+++ b/src/module/bar/index.ts
@@ -6,8 +6,9 @@ import onBarAdd from './onBarAdd';
 import onBarEdit from './onBarEdit';
 import onBarRemove from './onBarRemove';
 import onBarHW from './onBarHW';
+import { SlackMessageEvent } from '../../slack/event';
 
-const isQualified = (event: any, user: UserType) => {
+const isQualified = (event: SlackMessageEvent, user: UserType) => {
     const isUserQualified = (() => {
         if (user.userControl === 'whitelist') {
             if (!user.userWhitelist) return false;
@@ -31,7 +32,7 @@ const isQualified = (event: any, user: UserType) => {
     return isUserQualified && isChannelQualified;
 }
 
-const onBar = async (event: any, user: UserType) => {
+const onBar = async (event: SlackMessageEvent, user: UserType) => {
   if (!isQualified(event, user)) return;
   if (await isAttack(event)) return;
 

--- a/src/module/bar/onBarAdd.ts
+++ b/src/module/bar/onBarAdd.ts
@@ -91,7 +91,7 @@ const onBarAdd = async ({ command, args }: QueryType, event: SlackMessageEvent, 
       });
 
       await replySuccess(event, user, `${user.name}님의 진행중인 일에 *${content}* 를 추가했어요!`, 'add', 
-        { forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None });
+        { forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : undefined });
     }
   }));
 }

--- a/src/module/bar/onBarAdd.ts
+++ b/src/module/bar/onBarAdd.ts
@@ -1,10 +1,11 @@
 import { UserType } from '../../database/user';
-import { replySuccess, replyDdokddul } from '../../etc/postMessage';
+import { replySuccess, replyDdokddul, ForceMuteType } from '../../etc/postMessage';
 import { getArg, QueryType } from '../../etc/parseQuery';
 import { isInteger } from '../../etc/isInteger';
 import preprocessContent from '../../etc/preprocessContent';
 import { addBar, getBars } from '../../database/bar';
 import { validateBar } from '../../etc/validateBar';
+import { SlackMessageEvent } from '../../slack/event';
 
 let isSlackDecoration = (text: string) => {
   let match = text.match(/[~_]+/);
@@ -28,7 +29,7 @@ function makeUnique<T>(arr: T[]) {
   return Array.from(new Set<T>(arr));
 }
 
-const onBarAdd = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onBarAdd = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
   let bars = await getBars(user.id);
 
   const progArg = getArg(['--progress', '--prog', '-p'], args);
@@ -90,7 +91,7 @@ const onBarAdd = async ({ command, args }: QueryType, event: any, user: UserType
       });
 
       await replySuccess(event, user, `${user.name}님의 진행중인 일에 *${content}* 를 추가했어요!`, 'add', 
-      {forceUnmute: (user.userControl === 'blacklist')});
+        { forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None });
     }
   }));
 }

--- a/src/module/bar/onBarDefault.ts
+++ b/src/module/bar/onBarDefault.ts
@@ -5,9 +5,10 @@ import { QueryType } from '../../etc/parseQuery';
 import { formatBar } from './barFormatter';
 import { replyMessage, replySuccess } from '../../etc/postMessage';
 import { emoji } from '../../etc/theme';
+import { SlackMessageEvent } from '../../slack/event';
 const bulletEmoji = [":one:", ":two:", ":three:", ":four:", ":five:", ":six:", ":seven:", ":eight:", ":nine:", ":keycap_ten:"];
 
-const onBarDefault = async (query: QueryType, event: any, user: UserType) => {
+const onBarDefault = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     const allBars = await getBars(user.id);
     const bars = allBars;
 

--- a/src/module/bar/onBarEdit.ts
+++ b/src/module/bar/onBarEdit.ts
@@ -1,13 +1,14 @@
 import { UserType } from '../../database/user';
-import { replyDdokddul, replyFail, replySuccess } from '../../etc/postMessage';
+import { ForceMuteType, replyDdokddul, replyFail, replySuccess } from '../../etc/postMessage';
 import { getArg, QueryType } from '../../etc/parseQuery';
 import { isInteger } from '../../etc/isInteger';
 import preprocessContent from '../../etc/preprocessContent';
 import { BarType, editBar, getBars } from '../../database/bar';
 import { validateBar } from '../../etc/validateBar';
+import { SlackMessageEvent } from '../../slack/event';
 
 
-const onBarEdit = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onBarEdit = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
     let bars = await getBars(user.id);
 
     const progArg = getArg(['--progress', '--prog', '-p'], args);
@@ -119,7 +120,9 @@ const onBarEdit = async ({ command, args }: QueryType, event: any, user: UserTyp
 
   for(let content of Array.from(contents)) {
     if (await editBar(content, change)) {
-      await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 의 ${changeString} 바꾸었어요!`, 'edit', {forceUnmute: true});
+      await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 의 ${changeString} 바꾸었어요!`, 'edit', {
+        forceMuteType: ForceMuteType.Unmute
+      });
     } else {
       await replyFail(event, user, `${user.name}님의 할 일에서 *${content}* 을 바꾸는 데 실패했어요...`);
     }

--- a/src/module/bar/onBarHW.ts
+++ b/src/module/bar/onBarHW.ts
@@ -4,9 +4,10 @@ import { emoji } from '../../etc/theme';
 import { replyDdokddul, replySuccess } from '../../etc/postMessage';
 import { QueryType } from '../../etc/parseQuery';
 import { getLatestGreenGolds, greenGoldToHrefNoLevel, GreenGoldType } from '../../database/greengold';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onBarHW = async (query: QueryType, event: any, user: UserType) => {
+const onBarHW = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     const numProblems = user.numProbsPerCycle || 1;
     console.log(user.numProbsPerCycle, numProblems);
     const problems = await getLatestGreenGolds(user.command, numProblems);

--- a/src/module/bar/onBarRemove.ts
+++ b/src/module/bar/onBarRemove.ts
@@ -43,7 +43,7 @@ const onBarRemove = async ({ command }: QueryType, event: SlackMessageEvent, use
     for(let content of Array.from(contents)) {
       if (await removeBar({ owner: user.id, content })) {
         await replySuccess(event, user, `${user.name}님의 진행중인 일에서 *${content}* 를 제거했어요!`, 'remove', {
-          forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None
+          forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : undefined
         });
       } else {
         await replyFail(event, user, `${user.name}님의 진행중인 일에서 *${content}* 를 제거하는 데 실패했어요...`);

--- a/src/module/bar/onBarRemove.ts
+++ b/src/module/bar/onBarRemove.ts
@@ -1,12 +1,13 @@
 import { UserType } from '../../database/user';
-import { replySuccess, replyDdokddul, replyFail } from '../../etc/postMessage';
+import { replySuccess, replyDdokddul, replyFail, ForceMuteType } from '../../etc/postMessage';
 import { QueryType } from '../../etc/parseQuery';
 import preprocessContent from '../../etc/preprocessContent';
 import { isInteger } from '../../etc/isInteger';
 import { getBars, removeBar } from '../../database/bar';
+import { SlackMessageEvent } from '../../slack/event';
 
 
-const onBarRemove = async ({ command }: QueryType, event: any, user: UserType) => {
+const onBarRemove = async ({ command }: QueryType, event: SlackMessageEvent, user: UserType) => {
     const bars = await getBars(user.id);
     
     if (command.length === 1) {
@@ -41,7 +42,9 @@ const onBarRemove = async ({ command }: QueryType, event: any, user: UserType) =
 
     for(let content of Array.from(contents)) {
       if (await removeBar({ owner: user.id, content })) {
-        await replySuccess(event, user, `${user.name}님의 진행중인 일에서 *${content}* 를 제거했어요!`, 'remove', {forceUnmute: (user.userControl === 'blacklist')});
+        await replySuccess(event, user, `${user.name}님의 진행중인 일에서 *${content}* 를 제거했어요!`, 'remove', {
+          forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None
+        });
       } else {
         await replyFail(event, user, `${user.name}님의 진행중인 일에서 *${content}* 를 제거하는 데 실패했어요...`);
       }

--- a/src/module/code/index.ts
+++ b/src/module/code/index.ts
@@ -1,7 +1,8 @@
 import { replyMessage } from '../../etc/postMessage';
+import { SlackMessageEvent } from '../../slack/event';
 import isAttack from '../isAttack';
 
-const onCode = async (event: any) => {
+const onCode = async (event: SlackMessageEvent) => {
     if (await isAttack(event)) return;
     
     const text : string = event.text;

--- a/src/module/echo/index.ts
+++ b/src/module/echo/index.ts
@@ -1,7 +1,8 @@
 import { replyMessage } from '../../etc/postMessage';
+import { SlackMessageEvent } from '../../slack/event';
 import isAttack from '../isAttack';
 
-const onEcho = async (event: any) => {
+const onEcho = async (event: SlackMessageEvent) => {
     if (await isAttack(event)) return;
 //    if (event.thread_ts && Number.parseFloat(event.thread_ts) < (new Date().getTime() / 1000) - 5 * 60) return;
     

--- a/src/module/isAttack.ts
+++ b/src/module/isAttack.ts
@@ -1,10 +1,11 @@
 import { emoji } from "../etc/theme";
 import { replyMessage } from "../etc/postMessage";
+import { SlackMessageEvent } from "../slack/event";
 
-const isAttack = async (event: any) => {
+const isAttack = async (event: SlackMessageEvent) => {
     const text : string = event.text;
     const tokens = text.split(' ').map((token) => token.trim());
-    const date = new Date(event.ts * 1000);
+    const date = new Date(Number(event.ts) * 1000);
 
     if (text.length > 10000) {
       await replyMessage(event, undefined, {

--- a/src/module/onMessage.ts
+++ b/src/module/onMessage.ts
@@ -9,14 +9,15 @@ import { webClient } from '../index';
 import { emoji } from '../etc/theme';
 import { replyMessage } from '../etc/postMessage';
 import { addMessage } from '../database/message';
+import { SlackMessageEvent } from '../slack/event';
 
 const turnOnTimestamp = new Date().getTime() / 1000;
 
 let lastUser: string;
 let nowUser: string;
 
-const onMessage = async (event: any) => {
-    if (event.ts < turnOnTimestamp) return;
+const onMessage = async (event: SlackMessageEvent) => {
+    if (Number(event.ts) < turnOnTimestamp) return;
 //    if (isTesting && event.channel !== cstodoTestChannel) return;
     if (!event.text || !event.user) return;
     if (event.thread_ts) return;

--- a/src/module/todo/index.ts
+++ b/src/module/todo/index.ts
@@ -15,8 +15,9 @@ import parseQuery from '../../etc/parseQuery';
 import isAttack from '../isAttack';
 import { isThemeType, UserType } from '../../database/user';
 import { addEmoji } from '../../etc/postMessage';
+import { SlackMessageEvent } from '../../slack/event';
 
-const isQualified = (event: any, user: UserType) => {
+const isQualified = (event: SlackMessageEvent, user: UserType) => {
   
     const isUserQualified = (() => {
         if (user.userControl === 'whitelist') {
@@ -41,7 +42,7 @@ const isQualified = (event: any, user: UserType) => {
     return isUserQualified && isChannelQualified;
 }
 
-const onTodo = async (event: any, user: UserType) => {
+const onTodo = async (event: SlackMessageEvent, user: UserType) => {
   if (await isAttack(event)) return;
 
   const text : string = event.text;

--- a/src/module/todo/onTodoAdd.ts
+++ b/src/module/todo/onTodoAdd.ts
@@ -1,11 +1,12 @@
 import { UserType } from '../../database/user';
 import { addCstodo, getCstodos } from '../../database/cstodo';
 import { emoji } from '../../etc/theme';
-import { replySuccess, replyDdokddul } from '../../etc/postMessage';
+import { replySuccess, replyDdokddul, ForceMuteType } from '../../etc/postMessage';
 import { getArg, QueryType } from '../../etc/parseQuery';
 import stringToTime from '../../etc/stringToTime';
 import { reduceEachTrailingCommentRange } from 'typescript';
 import preprocessContent from '../../etc/preprocessContent';
+import { SlackMessageEvent } from '../../slack/event';
 
 let isSlackDecoration = (text: string) => {
   let match = text.match(/[~_]+/);
@@ -30,7 +31,7 @@ function makeUnique<T>(arr: T[]) {
   return Array.from(new Set<T>(arr));
 }
 
-const onTodoAdd = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onTodoAdd = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
   let todo = await getCstodos(user.id);
 
   const dueArg = getArg(['--due', '-d', '--time', '-t'], args);
@@ -72,7 +73,7 @@ const onTodoAdd = async ({ command, args }: QueryType, event: any, user: UserTyp
       });
 
       await replySuccess(event, user, `${user.name}님의 할 일에 *${content}* 를 추가했어요!`, 'add', 
-      {forceUnmute: (user.userControl === 'blacklist')});
+        { forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None });
     }
   }));
 }

--- a/src/module/todo/onTodoAdd.ts
+++ b/src/module/todo/onTodoAdd.ts
@@ -73,7 +73,7 @@ const onTodoAdd = async ({ command, args }: QueryType, event: SlackMessageEvent,
       });
 
       await replySuccess(event, user, `${user.name}님의 할 일에 *${content}* 를 추가했어요!`, 'add', 
-        { forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None });
+        { forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : undefined });
     }
   }));
 }

--- a/src/module/todo/onTodoAll.ts
+++ b/src/module/todo/onTodoAll.ts
@@ -6,8 +6,9 @@ import { emoji } from '../../etc/theme';
 import { replyMessage, replySuccess } from '../../etc/postMessage';
 import timeToString from '../../etc/timeToString';
 import { QueryType } from '../../etc/parseQuery';
+import { SlackMessageEvent } from '../../slack/event';
 
-const onTodoAll = async (query: QueryType, event: any, user: UserType) => {
+const onTodoAll = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     const cstodo = await getCstodos(user.id);
 
     if (cstodo.length > 0) {

--- a/src/module/todo/onTodoEdit.ts
+++ b/src/module/todo/onTodoEdit.ts
@@ -1,11 +1,12 @@
 import { getUser, UserType } from '../../database/user';
 import { addCstodo, CstodoType, editCstodo, getCstodos } from '../../database/cstodo';
 import { emoji } from '../../etc/theme';
-import { replyDdokddul, replyFail, replySuccess } from '../../etc/postMessage';
+import { ForceMuteType, replyDdokddul, replyFail, replySuccess } from '../../etc/postMessage';
 import { getArg, QueryType } from '../../etc/parseQuery';
 import stringToTime from '../../etc/stringToTime';
 import timeToString from '../../etc/timeToString';
 import preprocessContent from '../../etc/preprocessContent';
+import { SlackMessageEvent } from '../../slack/event';
 
 const isInteger = (s: string) => {
   for (let c of s.split('')) {
@@ -14,7 +15,7 @@ const isInteger = (s: string) => {
   return true;
 }
 
-const onTodoEdit = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onTodoEdit = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
   let todo = await getCstodos(user.id);
 
   const dueArg = getArg(['--due', '-d', '--time', '-t'], args);
@@ -109,7 +110,7 @@ const onTodoEdit = async ({ command, args }: QueryType, event: any, user: UserTy
 
   for(let content of Array.from(contents)) {
     if (await editCstodo(content, change)) {
-      await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 의 ${changeString} 바꾸었어요!`, 'edit', {forceUnmute: true});
+      await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 의 ${changeString} 바꾸었어요!`, 'edit', { forceMuteType: ForceMuteType.Unmute });
     } else {
       await replyFail(event, user, `${user.name}님의 할 일에서 *${content}* 을 바꾸는 데 실패했어요...`);
     }

--- a/src/module/todo/onTodoFuck.ts
+++ b/src/module/todo/onTodoFuck.ts
@@ -3,9 +3,10 @@ import { replyMessage } from '../../etc/postMessage';
 import { webClient } from '../../index';
 import { UserType } from '../../database/user';
 import { QueryType } from '../../etc/parseQuery';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onTodoFuck = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onTodoFuck = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
     await replyMessage(event, user, {
       text: emoji('fuck', user.theme).repeat(23),
       username: `${user.name}님의 비서`,

--- a/src/module/todo/onTodoHW.ts
+++ b/src/module/todo/onTodoHW.ts
@@ -4,9 +4,10 @@ import { emoji } from '../../etc/theme';
 import { replyDdokddul, replySuccess } from '../../etc/postMessage';
 import { QueryType } from '../../etc/parseQuery';
 import { getLatestGreenGolds, greenGoldToHrefNoLevel, GreenGoldType } from '../../database/greengold';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onTodoHW = async (query: QueryType, event: any, user: UserType) => {
+const onTodoHW = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     const numProblems = user.numProbsPerCycle || 1;
     console.log(user.numProbsPerCycle, numProblems);
     const problems = await getLatestGreenGolds(user.command, numProblems);

--- a/src/module/todo/onTodoHelp.ts
+++ b/src/module/todo/onTodoHelp.ts
@@ -2,6 +2,7 @@ import { UserType } from '../../database/user';
 import { emoji } from '../../etc/theme';
 import { QueryType } from '../../etc/parseQuery';
 import { replyMessage } from '../../etc/postMessage';
+import { SlackMessageEvent } from '../../slack/event';
 
 // TODO: Add subcommands and add argument details
 
@@ -17,7 +18,7 @@ const helpText = (user: UserType) => {
 \`${command} blob\` 또는 \`${command} weeb\`: ${command} 봇의 프로필을 바꿀 수 있습니다.`
 }
   
-const onTodoHelp = async (query: QueryType, event: any, user: UserType) => {
+const onTodoHelp = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     await replyMessage(event, user, {
       text: helpText(user),
       channel: event.channel,

--- a/src/module/todo/onTodoLength.ts
+++ b/src/module/todo/onTodoLength.ts
@@ -3,9 +3,10 @@ import { getCstodos } from '../../database/cstodo';
 import { emoji } from '../../etc/theme';
 import { replySuccess } from '../../etc/postMessage';
 import { QueryType } from '../../etc/parseQuery';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onTodoLength = async (query: QueryType, event: any, user: UserType) => {
+const onTodoLength = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     const cstodo = await getCstodos(user.id);
 
     await replySuccess(event, user, `와... ${user.name}님이 할 일이 총 ${cstodo.length} 개가 있어요... ${emoji('cs')}`);

--- a/src/module/todo/onTodoMute.ts
+++ b/src/module/todo/onTodoMute.ts
@@ -1,10 +1,11 @@
 import { emoji } from '../../etc/theme';
-import { replyMessage } from '../../etc/postMessage';
+import { ForceMuteType, replyMessage } from '../../etc/postMessage';
 import { setMuted, UserType } from '../../database/user';
 import { QueryType } from '../../etc/parseQuery';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onTodoMute = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onTodoMute = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
     const text : string = event.text;
     const tokens = text.split(' ').map((token) => token.trim());
     
@@ -17,7 +18,7 @@ const onTodoMute = async ({ command, args }: QueryType, event: any, user: UserTy
             channel: event.channel,
             icon_emoji: emoji('default', user.theme),
         }, {
-            forceUnmute: true,
+            forceMuteType: ForceMuteType.Unmute,
         });
     } else {
         await setMuted(user.command, false);
@@ -27,7 +28,7 @@ const onTodoMute = async ({ command, args }: QueryType, event: any, user: UserTy
             channel: event.channel,
             icon_emoji: emoji('default', user.theme),
         }, {
-            forceUnmute: true,
+            forceMuteType: ForceMuteType.Unmute,
         });
     }
 }

--- a/src/module/todo/onTodoOverflow.ts
+++ b/src/module/todo/onTodoOverflow.ts
@@ -2,9 +2,10 @@ import { UserType } from '../../database/user';
 import { getCstodos, removeCstodo } from '../../database/cstodo';
 import { replyMessage } from '../../etc/postMessage';
 import { QueryType } from '../../etc/parseQuery';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onTodoOverflow = async (query: QueryType, event: any, user: UserType) => {
+const onTodoOverflow = async (query: QueryType, event: SlackMessageEvent, user: UserType) => {
     const cstodo = await getCstodos(user.id);
 
     const maxLen = Math.max(...cstodo.map((item) => item.content.length));

--- a/src/module/todo/onTodoRemove.ts
+++ b/src/module/todo/onTodoRemove.ts
@@ -1,14 +1,15 @@
 import { UserType } from '../../database/user';
 import { getCstodos, removeCstodo } from '../../database/cstodo';
 import { emoji } from '../../etc/theme';
-import { replySuccess, replyDdokddul, replyFail } from '../../etc/postMessage';
+import { replySuccess, replyDdokddul, replyFail, ForceMuteType } from '../../etc/postMessage';
 import { Query } from 'mongoose';
 import { QueryType } from '../../etc/parseQuery';
 import preprocessContent from '../../etc/preprocessContent';
 import { isInteger } from '../../etc/isInteger';
+import { SlackMessageEvent } from '../../slack/event';
 
 
-const onTodoRemove = async ({ command }: QueryType, event: any, user: UserType) => {
+const onTodoRemove = async ({ command }: QueryType, event: SlackMessageEvent, user: UserType) => {
     const todo = await getCstodos(user.id);
     
     if (command.length === 1) {
@@ -43,7 +44,9 @@ const onTodoRemove = async ({ command }: QueryType, event: any, user: UserType) 
 
     for(let content of Array.from(contents)) {
       if (await removeCstodo({ owner: user.id, content })) {
-        await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 를 제거했어요!`, 'remove', {forceUnmute: (user.userControl === 'blacklist')});
+        await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 를 제거했어요!`, 'remove', {
+          forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None
+        });
       } else {
         await replyFail(event, user, `${user.name}님의 할 일에서 *${content}* 를 제거하는 데 실패했어요...`);
       }

--- a/src/module/todo/onTodoRemove.ts
+++ b/src/module/todo/onTodoRemove.ts
@@ -45,7 +45,7 @@ const onTodoRemove = async ({ command }: QueryType, event: SlackMessageEvent, us
     for(let content of Array.from(contents)) {
       if (await removeCstodo({ owner: user.id, content })) {
         await replySuccess(event, user, `${user.name}님의 할 일에서 *${content}* 를 제거했어요!`, 'remove', {
-          forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : ForceMuteType.None
+          forceMuteType: user.userControl === 'blacklist' ? ForceMuteType.Unmute : undefined
         });
       } else {
         await replyFail(event, user, `${user.name}님의 할 일에서 *${content}* 를 제거하는 데 실패했어요...`);

--- a/src/module/todo/onTodoSearch.ts
+++ b/src/module/todo/onTodoSearch.ts
@@ -3,9 +3,10 @@ import { CstodoType, getCstodos } from '../../database/cstodo';
 import { emoji } from '../../etc/theme';
 import { replyDdokddul, replySuccess } from '../../etc/postMessage';
 import { QueryType } from '../../etc/parseQuery';
+import { SlackMessageEvent } from '../../slack/event';
 
 // Needs refactor......
-const onTodoSearch = async (rawQuery: QueryType, event: any, user: UserType) => {
+const onTodoSearch = async (rawQuery: QueryType, event: SlackMessageEvent, user: UserType) => {
     const text : string = event.text;
     const tokens = text.split(' ').map((token) => token.trim());
     const query = tokens.slice(2).join(' ').trim();

--- a/src/module/todo/onTodoSet.ts
+++ b/src/module/todo/onTodoSet.ts
@@ -4,10 +4,11 @@ import { getArg, QueryType } from '../../etc/parseQuery';
 import { addEmoji, replyDdokddul, replySuccess } from '../../etc/postMessage';
 import { cstodoTestChannel } from '../../config';
 import axios from 'axios';
+import { SlackMessageEvent } from '../../slack/event';
 
 const negativeWords = ['off', 'no', 'none', 'false', '0', 'never'];
 
-const onTodoSet = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onTodoSet = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
 
     if (event.user !== user.owner && event.user !== 'UV6HYQD3J' && event.user != 'UV8DYMMV5') {
         addEmoji(event, 'sad');

--- a/src/module/todo/onTodoTheme.ts
+++ b/src/module/todo/onTodoTheme.ts
@@ -3,9 +3,10 @@ import { replyDdokddul, replyMessage, replySuccess } from '../../etc/postMessage
 import { QueryType } from '../../etc/parseQuery';
 import { isThemeType, setTheme, UserType } from '../../database/user';
 import preprocessContent from '../../etc/preprocessContent';
+import { SlackMessageEvent } from '../../slack/event';
 
   
-const onTodoTheme = async ({ command, args }: QueryType, event: any, user: UserType) => {
+const onTodoTheme = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
     const newTheme = preprocessContent(command[0]);
 
     if (!isThemeType(newTheme)) {

--- a/src/slack/event.ts
+++ b/src/slack/event.ts
@@ -1,0 +1,9 @@
+
+export interface SlackMessageEvent {
+    type: 'message';
+    channel: string;
+    user: string;
+    text: string;
+    ts: string;
+    thread_ts?: string;
+}


### PR DESCRIPTION
any로 되어 있던 슬랙 메시지 이벤트를 전부 slack api 문서(https://api.slack.com/events/message?filter=Events) 에 있는 스키마에 따라 사용되고 있는 값들만 타입으로 추가하고 수정이 필요한 부분(주로 ts 필드가 타입이 string인데 Number와 혼용되고 있던 부분)만 수정했습니다.

추가로, postMessages의 Options 인터페이스가 forceMute / forceUnmute 두개의 값을 옵션으로 사용하는데 두 값이 모두 muted 값을 강제로 어떻게 설정할지와 관련되어 있습니다. 그런데 같은 값에 대한 설정 옵션임에도 둘이 서로 다른 필드로 나뉘어져 있어 모호한 것 같아 하나로 합쳤습니다(forceMute와 forceUnmute가 모두 true일 때 동작이 명확하지 않음). forceMute 필드가 undefined면 mute 옵션을 강제로 변경하지 않음 / ForceMuteType.Mute면 강제로 mute / ForceMuteType.Unmute면 강제로 unmute 로 동작합니다.