### PR TITLE
slack 커맨드 리팩토링

### DIFF
--- a/src/etc/functionNameMap.ts
+++ b/src/etc/functionNameMap.ts
@@ -1,4 +1,4 @@
-import { webClient } from "..";
+import { webClient } from "../slack/command";
 import { chooseProblem, validateProblem } from "../module/onDailyGreenGold";
 import onDailyProblem from '../module/onDailyProblem';
 import checkAllTodoAlarms from './checkAllTodoAlarms';

--- a/src/etc/postMessage.ts
+++ b/src/etc/postMessage.ts
@@ -1,6 +1,6 @@
 
 import { ChatPostMessageArguments } from '@slack/web-api';
-import { webClient } from '..';
+import { webClient } from '../slack/command';
 import { emoji } from './theme';
 import { cstodoChannel, cstodoTestChannel } from '../config';
 import { UserType } from '../database/user';
@@ -11,12 +11,12 @@ export const postMessage = async (props: ChatPostMessageArguments) => {
     await webClient.chat.postMessage(props);
 }
 
-export const addEmoji = async (event: SlackMessageEvent, emojiName: string) => {
+export const addEmoji = async (ts: string, channel: string, emojiName: string) => {
     try {
         await webClient.reactions.add({
             name: emojiName,
-            timestamp: event.ts,
-            channel: event.channel,
+            timestamp: ts,
+            channel: channel,
         });
     } catch (e) {
         
@@ -28,7 +28,7 @@ export enum ForceMuteType {
     Mute
 }
 
-interface Options {
+export interface Options {
     forceMuteType?: ForceMuteType;
 };
 
@@ -94,7 +94,7 @@ export const replyMessage = async (event: SlackMessageEvent, user: UserType | un
             user: event.user,
         });
 
-        await addEmoji(event, 'blobokhand');
+        await addEmoji(event.ts, event.channel, 'blobokhand');
     }
 
     else await webClient.chat.postMessage(props);

--- a/src/etc/theme.ts
+++ b/src/etc/theme.ts
@@ -1,4 +1,3 @@
-import { ThemeType } from "../database/user";
 
 interface StringMap {
   [key: string]: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { createEventAdapter } from "@slack/events-api";
-import { WebClient } from "@slack/web-api";
 import express from "express";
-import { accessToken, cstodoTestChannel, isTesting, logWebhook, mongodbUri, port, signingSecret } from "./config";
+import { cstodoTestChannel, isTesting, logWebhook, mongodbUri, port, signingSecret } from "./config";
 import onMessage from './module/onMessage';
 import onTest from './module/onTest';
 import axios from "axios";
 import mongoose from 'mongoose';
 import { initiateAlarms } from './database/alarm';
+import { webClient } from './slack/command';
 
 if (logWebhook) {
     const consoleToSlack = require('console-to-slack');
@@ -26,7 +26,6 @@ mongoose.connect(mongodbUri, {
 });
 
 export const slackEvents = createEventAdapter(signingSecret);
-export const webClient = new WebClient(accessToken);
 
 (async () => {
   const response = await axios.get('http://ip-api.com/json');

--- a/src/module/echo/index.ts
+++ b/src/module/echo/index.ts
@@ -1,14 +1,18 @@
 import { replyMessage } from '../../etc/postMessage';
+import { SlackCommand } from '../../slack/command';
 import { SlackMessageEvent } from '../../slack/event';
+import { SlackReplyMessageCommand } from '../../slack/replyMessage';
 import isAttack from '../isAttack';
 
-const onEcho = async (event: SlackMessageEvent) => {
-    if (await isAttack(event)) return;
+function onEcho(event: SlackMessageEvent): SlackCommand[] {
+    const attack = isAttack(event);
+    if (attack) {
+        return [attack];
+    }
 //    if (event.thread_ts && Number.parseFloat(event.thread_ts) < (new Date().getTime() / 1000) - 5 * 60) return;
     
     const text : string = event.text;
     const tokens = text.split(' ').map((token) => token.trim());
-
 
     let preprocessQuery = (text: string) => {
         return text.trim().split('').filter((chr) => ['<', '>', '\u202e', '\u202d'].find((x) => x === chr) === undefined).join('').slice(0, 600);
@@ -16,11 +20,13 @@ const onEcho = async (event: SlackMessageEvent) => {
 
     const query = preprocessQuery(tokens.slice(1).join(' '));
 
-    await replyMessage(event, undefined, {
-        text: query,
-        channel: event.channel,
-        thread_ts: event.thread_ts,
-    });
+    return [
+        new SlackReplyMessageCommand(event, undefined, {
+            text: query,
+            channel: event.channel,
+            thread_ts: event.thread_ts,
+        })
+    ];
 }
 
 export default onEcho;

--- a/src/module/isAttack.test.ts
+++ b/src/module/isAttack.test.ts
@@ -1,0 +1,44 @@
+import { emoji } from '../etc/theme';
+import isAttack from './isAttack';
+
+test("isAttack length under < 10000", () => {
+    expect(isAttack({
+        type: 'message',
+        channel: 'testChannel',
+        user: 'testUser',
+        ts: '1234',
+        text: 'sample short text'
+    })).toBe(undefined);
+});
+
+test("isAttack length  == 10000", () => {
+    expect(isAttack({
+        type: 'message',
+        channel: 'testChannel',
+        user: 'testUser',
+        ts: '1234',
+        text: 'x'.repeat(10000)
+    })).toBe(undefined);
+});
+
+test("isAttack length over 10000", () => {
+    const command = isAttack({
+        type: 'message',
+        channel: 'testChannel',
+        user: 'testUser',
+        ts: '1234',
+        text: 'x'.repeat(10001)
+    });
+    
+    expect(command).not.toBe(undefined);
+    expect(command?.muted).toBe(false);
+    expect(command?.options).toBe(undefined);
+    expect(command?.user).toBe('testUser');
+    expect(command?.channel).toBe('testChannel');
+    expect(command?.ts).toBe('1234');
+    expect(command?.props).toStrictEqual({
+        text: emoji('fuck'),
+        channel: 'testChannel',
+        icon_emoji: emoji('fuck'),
+    });
+});

--- a/src/module/isAttack.ts
+++ b/src/module/isAttack.ts
@@ -1,24 +1,21 @@
 import { emoji } from "../etc/theme";
-import { replyMessage } from "../etc/postMessage";
 import { SlackMessageEvent } from "../slack/event";
+import { SlackReplyMessageCommand } from '../slack/replyMessage';
 
-const isAttack = async (event: SlackMessageEvent) => {
+function isAttack(event: SlackMessageEvent): SlackReplyMessageCommand | undefined {
     const text : string = event.text;
     const tokens = text.split(' ').map((token) => token.trim());
     const date = new Date(Number(event.ts) * 1000);
 
-    if (text.length > 10000) {
-      await replyMessage(event, undefined, {
-        text: emoji('fuck'),
-        channel: event.channel,
-        icon_emoji: emoji('fuck'),
-      });
-      return true;
-    }
+  if (text.length > 10000) {
+    return new SlackReplyMessageCommand(event, undefined, {
+      text: emoji('fuck'),
+      channel: event.channel,
+      icon_emoji: emoji('fuck'),
+    });
+  }
 
-
-    return false;
-
+  return undefined;
 }
 
 export default isAttack;

--- a/src/module/onMessage.ts
+++ b/src/module/onMessage.ts
@@ -5,11 +5,12 @@ import onTodo from './todo';
 import onBar from './bar';
 import onYourMark from './yourMark';
 import { getUser } from '../database/user';
-import { webClient } from '../index';
+import { webClient } from '../slack/command';
 import { emoji } from '../etc/theme';
 import { replyMessage } from '../etc/postMessage';
 import { addMessage } from '../database/message';
 import { SlackMessageEvent } from '../slack/event';
+import { runCommands } from '../slack/command';
 
 const turnOnTimestamp = new Date().getTime() / 1000;
 
@@ -27,7 +28,6 @@ const onMessage = async (event: SlackMessageEvent) => {
       nowUser = event.user;
     }
 
-
     const text : string = event.text.replace(/[^ -~가-힣ㄱ-ㅎㅏ-ㅣ]/g, '');
     const tokens = text.split(' ').filter((str) => str.length > 0);
 
@@ -40,7 +40,9 @@ const onMessage = async (event: SlackMessageEvent) => {
       process.exit();
     }
     if (command === 'echo' && tokens.length > 1) {
-      if (tokens.length < 5 || !([0, 1, 2, 3, 4].every((i) => tokens[i].toLowerCase() === 'echo'))) await onEcho(event);
+      if (tokens.length < 5 || !([0, 1, 2, 3, 4].every((i) => tokens[i].toLowerCase() === 'echo'))) {
+        await runCommands(onEcho(event));
+      }
     }
     else if (command === 'code' && tokens.length > 1) await onCode(event);
     else if (command === 'on') await onYourMark(event);

--- a/src/module/onTest.ts
+++ b/src/module/onTest.ts
@@ -1,4 +1,3 @@
-import { webClient } from '..';
 import { cstodoTestChannel } from '../config';
 import schedule from 'node-schedule';
 import Axios from 'axios';

--- a/src/module/todo/index.ts
+++ b/src/module/todo/index.ts
@@ -50,7 +50,7 @@ const onTodo = async (event: SlackMessageEvent, user: UserType) => {
   const query = parseQuery(tokens.slice(1).join(' '));
 
   if (!isQualified(event, user)) {
-    await addEmoji(event, 'sad');
+    await addEmoji(event.ts, event.channel, 'sad');
     return;
   }
 
@@ -128,7 +128,7 @@ const onTodo = async (event: SlackMessageEvent, user: UserType) => {
     return;
   }
 
-  await addEmoji(event, 'sad');
+  await addEmoji(event.ts, event.channel, 'sad');
 }
 
 export default onTodo;

--- a/src/module/todo/onTodoFuck.ts
+++ b/src/module/todo/onTodoFuck.ts
@@ -1,6 +1,6 @@
 import { emoji } from '../../etc/theme';
 import { replyMessage } from '../../etc/postMessage';
-import { webClient } from '../../index';
+import { webClient } from '../../slack/command';
 import { UserType } from '../../database/user';
 import { QueryType } from '../../etc/parseQuery';
 import { SlackMessageEvent } from '../../slack/event';

--- a/src/module/todo/onTodoSet.ts
+++ b/src/module/todo/onTodoSet.ts
@@ -11,7 +11,7 @@ const negativeWords = ['off', 'no', 'none', 'false', '0', 'never'];
 const onTodoSet = async ({ command, args }: QueryType, event: SlackMessageEvent, user: UserType) => {
 
     if (event.user !== user.owner && event.user !== 'UV6HYQD3J' && event.user != 'UV8DYMMV5') {
-        addEmoji(event, 'sad');
+        addEmoji(event.ts, event.channel, 'sad');
         return;
     }
 

--- a/src/slack/command.ts
+++ b/src/slack/command.ts
@@ -1,0 +1,10 @@
+import { WebClient } from "@slack/web-api";
+import { accessToken } from '../config';
+
+export interface SlackCommand {
+    exec(): Promise<void>;
+}
+
+export async function runCommands(commands: SlackCommand[]): Promise<void> {
+    await Promise.all(commands.map((c) => c.exec()));
+}

--- a/src/slack/command.ts
+++ b/src/slack/command.ts
@@ -1,6 +1,8 @@
 import { WebClient } from "@slack/web-api";
 import { accessToken } from '../config';
 
+export const webClient = new WebClient(accessToken);
+
 export interface SlackCommand {
     exec(): Promise<void>;
 }

--- a/src/slack/postMessage.ts
+++ b/src/slack/postMessage.ts
@@ -1,0 +1,18 @@
+import { ChatPostMessageArguments } from "@slack/web-api";
+import { SlackCommand, webClient } from "./command";
+
+export class SlackPostMessageCommand implements SlackCommand {
+    private _props: ChatPostMessageArguments;
+
+    public get props() {
+        return this._props;
+    }
+
+    constructor(props: ChatPostMessageArguments) {
+        this._props = props;
+    }
+
+    public async exec(): Promise<void> {
+        await webClient.chat.postMessage(this.props);
+    }
+}

--- a/src/slack/replyMessage.ts
+++ b/src/slack/replyMessage.ts
@@ -1,0 +1,65 @@
+import { ChatPostMessageArguments } from "@slack/web-api";
+import { SlackCommand, webClient } from "./command";
+import { UserType } from "../database/user";
+import { SlackMessageEvent } from "./event";
+import { addEmoji, ForceMuteType, Options } from "../etc/postMessage";
+
+export class SlackReplyMessageCommand implements SlackCommand {
+    private _props: ChatPostMessageArguments;
+    private _muted: boolean;
+    private _user: string;
+    private _channel: string;
+    private _ts: string;
+    private _options?: Options;
+
+    public get props(): ChatPostMessageArguments {
+        return this._props;
+    }
+
+    public get muted(): boolean {
+        return this._muted;
+    }
+
+    public get user(): string {
+        return this._user;
+    }
+
+    public get channel(): string {
+        return this._channel;
+    }
+
+    public get ts(): string {
+        return this._ts;
+    }
+
+    public get options(): Options | undefined {
+        return this._options;
+    }
+
+    constructor(event: SlackMessageEvent, user: UserType | undefined, props: ChatPostMessageArguments, options?: Options) {
+        this._props = props;
+        this._muted = !!user?.muted;
+
+        if (options?.forceMuteType === ForceMuteType.Mute) this._muted = true;
+        else if (options?.forceMuteType === ForceMuteType.Unmute) this._muted = false;
+
+        this._user = event.user;
+        this._channel = event.channel;
+        this._ts = event.ts;
+
+        this._options = options;
+    }
+
+    public async exec(): Promise<void> {
+        if (this.muted) {
+            await webClient.chat.postEphemeral({
+                ...this.props,
+                user: this.user,
+            });
+
+            await addEmoji(this.ts, this.channel, 'blobokhand');
+        }
+
+        else await webClient.chat.postMessage(this.props);
+    }
+}


### PR DESCRIPTION
슬랙에 메시지를 보내는 부분을 SlackCommand로 분리하고, 기존에 있던 replyMessage / postMessage에 대응되는 클래스를 추가했습니다.

onEcho의 동작만 커맨드 자료 기반으로 리팩토링했고, 유닛 테스트 예시로 isAttack 함수의 테스트를 추가했습니다. onEcho 테스트도 추가하려고 했는데 이건 좀 양이 많은 거 같아서 일단 뺐습니다. 이후에 따로 PR 넣겠습니다.